### PR TITLE
replaced interp2d with RegularGridInterpolator

### DIFF
--- a/pybamm/solvers/processed_variable.py
+++ b/pybamm/solvers/processed_variable.py
@@ -222,7 +222,7 @@ class ProcessedVariable(object):
             self._interpolation_function = interp.RegularGridInterpolator(
                 (self.t_pts,
                 pts_for_interp),
-                entries_for_interp,
+                entries_for_interp.T,
                 method="linear",
                 fill_value=np.nan,
                 bounds_error=False,

--- a/pybamm/solvers/processed_variable.py
+++ b/pybamm/solvers/processed_variable.py
@@ -5,7 +5,7 @@ import casadi
 import numbers
 import numpy as np
 import pybamm
-import scipy.interpolate as interp
+from scipy.interpolate import RegularGridInterpolator
 from scipy.integrate import cumulative_trapezoid
 
 
@@ -219,7 +219,7 @@ class ProcessedVariable(object):
         else:
             # function of space and time. Note that the order of 't' and 'space'
             # is the reverse of what you'd expect
-            self._interpolation_function = interp.interp2d(
+            self._interpolation_function = RegularGridInterpolator(
                 self.t_pts,
                 pts_for_interp,
                 entries_for_interp,
@@ -595,7 +595,7 @@ class Interpolant2D:
     def __init__(
         self, first_dim_pts_for_interp, second_dim_pts_for_interp, entries_for_interp
     ):
-        self.interpolant = interp.interp2d(
+        self.interpolant = RegularGridInterpolator(
             second_dim_pts_for_interp,
             first_dim_pts_for_interp,
             entries_for_interp[:, :, 0],

--- a/pybamm/solvers/processed_variable.py
+++ b/pybamm/solvers/processed_variable.py
@@ -5,7 +5,7 @@ import casadi
 import numbers
 import numpy as np
 import pybamm
-from scipy.interpolate import RegularGridInterpolator
+import scipy.interpolate as interp
 from scipy.integrate import cumulative_trapezoid
 
 
@@ -219,11 +219,11 @@ class ProcessedVariable(object):
         else:
             # function of space and time. Note that the order of 't' and 'space'
             # is the reverse of what you'd expect
-            self._interpolation_function = RegularGridInterpolator(
-                self.t_pts,
+            self._interpolation_function = interp.RegularGridInterpolator(
+                (self.t_pts,
                 pts_for_interp,
-                entries_for_interp,
-                kind="linear",
+                entries_for_interp),
+                method="linear",
                 fill_value=np.nan,
                 bounds_error=False,
             )
@@ -595,11 +595,11 @@ class Interpolant2D:
     def __init__(
         self, first_dim_pts_for_interp, second_dim_pts_for_interp, entries_for_interp
     ):
-        self.interpolant = RegularGridInterpolator(
-            second_dim_pts_for_interp,
+        self.interpolant = interp.RegularGridInterpolator(
+            (second_dim_pts_for_interp,
             first_dim_pts_for_interp,
-            entries_for_interp[:, :, 0],
-            kind="linear",
+            entries_for_interp[:, :, 0]),
+            method="linear",
             fill_value=np.nan,
             bounds_error=False,
         )

--- a/pybamm/solvers/processed_variable.py
+++ b/pybamm/solvers/processed_variable.py
@@ -221,8 +221,8 @@ class ProcessedVariable(object):
             # is the reverse of what you'd expect
             self._interpolation_function = interp.RegularGridInterpolator(
                 (self.t_pts,
-                pts_for_interp,
-                entries_for_interp),
+                pts_for_interp),
+                entries_for_interp,
                 method="linear",
                 fill_value=np.nan,
                 bounds_error=False,
@@ -597,8 +597,8 @@ class Interpolant2D:
     ):
         self.interpolant = interp.RegularGridInterpolator(
             (second_dim_pts_for_interp,
-            first_dim_pts_for_interp,
-            entries_for_interp[:, :, 0]),
+            first_dim_pts_for_interp),
+            entries_for_interp[:, :, 0],
             method="linear",
             fill_value=np.nan,
             bounds_error=False,


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all`
- [ ] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
